### PR TITLE
Add Health Check Endpoint to Prevent Server Sleep

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@ const app = express();
 
 const corsOptions = {
   origin: [
-    "http://localhost:3000",                   
-    "https://saathi-trust.vercel.app",        
+    "http://localhost:3000",
+    "https://saathi-trust.vercel.app",
     /^https:\/\/saathi-trust.*\.vercel\.app$/,
-    /^https:\/\/frontend-.*\.vercel\.app$/    
+    /^https:\/\/frontend-.*\.vercel\.app$/
   ],
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
@@ -23,10 +23,18 @@ const corsOptions = {
 app.use(cors(corsOptions));
 app.use(express.json());
 
+// New health check route for cron jobs and uptime monitors
+app.get("/health", (req, res) => {
+  res.status(200).json({
+    message: "Server is healthy",
+    uptime: process.uptime()
+  });
+});
+
 app.use("/api/auth", authRoutes);
 
 app.get("/api/hello", (req, res) => {
-  res.json({ 
+  res.json({
     message: "Hello from backend",
     timestamp: new Date().toISOString(),
     cors: "Configured for Vercel"
@@ -35,12 +43,13 @@ app.get("/api/hello", (req, res) => {
 
 app.use((err, req, res, next) => {
   console.error("Server error:", err);
-  res.status(500).json({ 
+  res.status(500).json({
     message: err.message || "Internal server error"
   });
 });
+
 app.use("*", (req, res) => {
-  res.status(404).json({ 
+  res.status(404).json({
     message: "Route not found",
     path: req.originalUrl
   });


### PR DESCRIPTION
### 🚀 Feat: Add Health Check Endpoint to Prevent Server Sleep

### **Description**

This PR introduces a new, super-lightweight `/health` endpoint to our backend. The main goal here is to keep our server wide awake 😴 on our free-tier hosting platform (Render).

Currently, the server goes to sleep after 15 minutes of inactivity. This leads to a frustratingly slow "cold start" delay for the first user who tries to log in or access the app, which is a major UX issue. 😩

This new endpoint is a simple `GET` route that does nothing but confirm the server is alive. We'll set up an external service like `cron-job.org` to hit this endpoint every few minutes, effectively tricking our server into thinking it's always in use.

**What's new in this PR?**

* ✅ Adds a new `GET /health` route.
* ⚡️ This route is incredibly fast and efficient; it doesn't touch the database or do any heavy lifting.
* 🎉 Returns a simple `200 OK` status and a JSON object to confirm the server is responsive.
* 🧹 The route is placed strategically in our code to be handled first, ensuring optimal performance.

This change is a huge win for our users, guaranteeing a consistently fast and smooth experience every time they visit our site.

**Testing**

To confirm this works, you can:
* Open your browser and navigate to `[Your Backend URL]/health`. You should see a "Server is healthy" message.
* The `cron-job.org` monitor should now show a "Successful" status on its next run, meaning our server won't be taking any more naps! ☕️